### PR TITLE
Prepare for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,4 @@ include $(PGXS)
 
 test_data:
 	./test_data_provider
-check: test_data
-	make installcheck
+check: test_data make installcheck


### PR DESCRIPTION
Using separate lines for rules causing warning message in both Debian and
RedHat builds. Without this fix, it reads;

warning: overriding commands for target `check`