### PR TITLE
Prepare for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ ifndef PG_CONFIG
 PG_CONFIG = pg_config
 endif
 
+REGRESS_PREP = test_data
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 test_data:
 	./test_data_provider
-check: test_data
-	make installcheck

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have PostgreSQL, you're ready to build topn. For this, you will need to
 
 You can run the regression tests as the following;
 
-    sudo PATH=/usr/local/pgsql/bin/:$PATH make check
+    sudo make installcheck
 
 Please note that the test dataset `customer_reviews_1998.csv` file is too big so it is handled by git-lfs.
 


### PR DESCRIPTION
Using separate lines for rules causing warning message in both Debian and
RedHat builds. Without this fix, it reads;

warning: overriding commands for target `check`