### PR TITLE
A custom type to return for topn function is added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,21 @@
 
 MODULES = topn
 EXTENSION = topn
-DATA =	topn--2.0.0.sql
-##README??
+EXTVERSIONS = 2.0.0 2.1.0
+DATA =	$(wildcard $(EXTENSION)--*--*.sql)
+DATA_built = $(foreach v,$(EXTVERSIONS),$(EXTENSION)--$(v).sql)
 
 REGRESS = add_agg union_agg char_tests null_tests add_union_tests copy_data customer_reviews_query join_tests
+
+# be explicit about the default target
+all:
+
+# generate each version's file installation file by concatenating
+# previous upgrade scripts
+$(EXTENSION)--2.0.0.sql: $(EXTENSION).sql
+	cat $^ > $@
+$(EXTENSION)--2.1.0.sql: $(EXTENSION)--2.0.0.sql $(EXTENSION)--2.0.0--2.1.0.sql
+	cat $^ > $@
 
 EXTRA_CLEAN += -r $(RPM_BUILD_ROOT)
 

--- a/topn--2.0.0--2.1.0.sql
+++ b/topn--2.0.0--2.1.0.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION topn(jsonb, integer);
+CREATE TYPE topn_record AS (item text, frequency bigint);
+CREATE FUNCTION topn(jsonb, integer)
+	RETURNS SETOF topn_record
+	AS 'MODULE_PATHNAME'
+	LANGUAGE C IMMUTABLE STRICT;

--- a/topn.control
+++ b/topn.control
@@ -1,4 +1,4 @@
 # topn extension
 comment = 'type for top-n JSONB'
-default_version = '2.0.0'
+default_version = '2.1.0'
 module_pathname = '$libdir/topn'

--- a/topn.sql
+++ b/topn.sql
@@ -16,9 +16,9 @@ CREATE FUNCTION topn_union(jsonb, jsonb)
 
 --trans function
 CREATE FUNCTION topn_union_trans(internal, jsonb)
-    RETURNS internal
-    AS 'MODULE_PATHNAME'
-    LANGUAGE C;
+	RETURNS internal
+	AS 'MODULE_PATHNAME'
+	LANGUAGE C;
 
 CREATE FUNCTION topn_add_trans(internal, text)
     RETURNS internal
@@ -29,7 +29,7 @@ CREATE FUNCTION topn_add_trans(internal, text)
 --
 CREATE FUNCTION topn_pack(internal)
     RETURNS jsonb
- 	AS 'MODULE_PATHNAME'
+	AS 'MODULE_PATHNAME'
     LANGUAGE C;
 --
 -- Aggregates
@@ -46,19 +46,19 @@ CREATE AGGREGATE topn_union_agg(jsonb)(
 );
 
 CREATE OPERATOR + (
-			leftarg = jsonb,
-			rightarg = jsonb,
-			procedure = topn_union,
-			commutator = +
+	leftarg = jsonb,
+	rightarg = jsonb,
+	procedure = topn_union,
+	commutator = +
 );
 
 COMMENT ON FUNCTION topn(top_items jsonb, n integer)
-    IS 'get the top n items from top_items';
+	IS 'get the top n items from top_items';
 COMMENT ON FUNCTION topn_add(top_items jsonb, item text)
-    IS 'insert the item into the top_items counter';
+	IS 'insert the item into the top_items counter';
 COMMENT ON FUNCTION topn_union(top_items jsonb, top_items2 jsonb)
-    IS 'take the union of the two top_items counter';
+	IS 'take the union of the two top_items counter';
 COMMENT ON AGGREGATE topn_add_agg(item text)
-    IS 'aggregate the items into one counter';
+	IS 'aggregate the items into one counter';
 COMMENT ON AGGREGATE topn_union_agg(item_counter jsonb)
-    IS 'aggregate the counters into one counter';
+	IS 'aggregate the counters into one counter';


### PR DESCRIPTION
This PR adds a new type called `topn` as a returning type to `topn` function which is needed for aggregate supports in Citus. The reason we needed this change can be seen in https://github.com/citusdata/citus/issues/2184