### PR TITLE
Update CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - env: PGVERSION=12
 before_install:
   - bash test_data_provider
-  - git clone -b v0.7.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.13 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - nuke_pg

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 install:
   - install_uncrustify
   - install_pg
+  - install_custom_pg
 before_script:
   - citus_indent --quiet --check
   - config_and_start_cluster

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 git:
   lfs_skip_smudge: true
-dist: trusty
+dist: bionic
 language: c
 branches:
   except: [ /^open-.*$/ ]
@@ -21,7 +21,6 @@ before_install:
 install:
   - install_uncrustify
   - install_pg
-  - install_custom_pg
 before_script:
   - citus_indent --quiet --check
   - config_and_start_cluster

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - env: PGVERSION=9.6
     - env: PGVERSION=10
     - env: PGVERSION=11
+    - env: PGVERSION=12
 before_install:
   - bash test_data_provider
   - git clone -b v0.7.1 --depth 1 https://github.com/citusdata/tools.git


### PR DESCRIPTION
This PR introduces 3 changes to how CI tests are run on travis
1. Start using Ubuntu 18.04 Bionic. Trusty EOL'd and is no longer supported by PGDG repositories. e.g. you can not install PG12 packages

2. Added PG12 to test matrix

3. Updated tools version to latest. There are some improvements to our `citus_indent` tool that can be useful here.

We will create PG12 packages for topn, and I feel the need to update CI tests here so that we do not break compatibility