### PR TITLE
Run PG13 tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - env: PGVERSION=10
     - env: PGVERSION=11
     - env: PGVERSION=12
+    - env: PGVERSION=13
 before_install:
   - bash test_data_provider
   - git clone -b v0.7.13 --depth 1 https://github.com/citusdata/tools.git

--- a/expected/customer_reviews_query_0.out
+++ b/expected/customer_reviews_query_0.out
@@ -2,7 +2,7 @@ SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int >= 13;
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 -- Create table to insert summaries.
@@ -47,9 +47,9 @@ order by 2 DESC, 1;
  0671014730 |       572
  0743527550 |       572
  0375700757 |       555
- 0871136791 |       553
+ 0871136791 |       555
  0679460691 |       551
- 0375402926 |       548
+ 0375402926 |       550
  0613221583 |       536
  0812550293 |       536
  1575110458 |       536

--- a/sql/customer_reviews_query.sql
+++ b/sql/customer_reviews_query.sql
@@ -1,3 +1,6 @@
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int >= 13;
+
 -- Create table to insert summaries.
 create table popular_products
 (


### PR DESCRIPTION
Added PG13 jobs to the CI configurations.

The current regression suite does not pass on PG13 with the following diff:

```diff
diff -U3 /home/travis/build/citusdata/postgresql-topn/expected/customer_reviews_query.out /home/travis/build/citusdata/postgresql-topn/results/customer_reviews_query.out
--- /home/travis/build/citusdata/postgresql-topn/expected/customer_reviews_query.out	2020-10-26 11:18:38.027654763 +0000
+++ /home/travis/build/citusdata/postgresql-topn/results/customer_reviews_query.out	2020-10-26 11:19:38.707530652 +0000
@@ -40,9 +40,9 @@
  0671014730 |       572
  0743527550 |       572
  0375700757 |       555
- 0871136791 |       555
+ 0871136791 |       553
  0679460691 |       551
- 0375402926 |       550
+ 0375402926 |       548
  0613221583 |       536
  0812550293 |       536
  1575110458 |       536
+exit 2
```