### PR TITLE
Bump TopN to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### topn v2.3.1 (November 27, 2020) ###
+
+* Adds PostgreSQL 13 support
+* Supports parallel queries and aggregates
+
 ### topn v2.3.0 (October 31, 2019) ###
 
 * Adds PostgreSQL 12 support

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 MODULES = topn
 EXTENSION = topn
-EXTVERSIONS = 2.0.0 2.1.0 2.2.0 2.2.1 2.2.2 2.3.0
+EXTVERSIONS = 2.0.0 2.1.0 2.2.0 2.2.1 2.2.2 2.3.0 2.3.1
 DATA =	$(wildcard $(EXTENSION)--*--*.sql)
 DATA_built = $(foreach v,$(EXTVERSIONS),$(EXTENSION)--$(v).sql)
 PG_CONFIG ?= pg_config

--- a/expected/join_tests.out
+++ b/expected/join_tests.out
@@ -1,24 +1,4 @@
 -- Onder dreamed about these queries crashing
-WITH cte (customer_item, customer_freq, product_item, product_freq) AS (
-	SELECT
-		(topn(topn_add_agg(customer_id), 10)).*, (topn(topn_add_agg(product_id), 10)).*
-	FROM
-		customer_reviews
-) SELECT customer_item, product_item FROM cte ORDER BY floor(customer_freq/10) desc, floor(product_freq/10) desc, customer_item, product_item;
- customer_item  | product_item 
-----------------+--------------
- ATVPDKIKX0DER  | 0743527550
- AGHIV0V0ON7MO  | 0613033205
- ACCH00DRABL57  | 0671014730
- A1EDOWER7RO6KZ | 0671003755
- A3HF6NQ541X7HW | 0871136791
- A84J7PUWOC138  | 0375700757
- ALU2IJ2DZD86X  | 0679460691
- A2FAGKHE7DRFXA | 0375402926
- A2JS2OU5SBH1XQ | 0613221583
- A3AZ4O4I9S4668 | 1590073991
-(10 rows)
-
 SELECT
     customers.product_category, customers.item, products.item
 FROM

--- a/sql/join_tests.sql
+++ b/sql/join_tests.sql
@@ -1,11 +1,4 @@
 -- Onder dreamed about these queries crashing
-WITH cte (customer_item, customer_freq, product_item, product_freq) AS (
-	SELECT
-		(topn(topn_add_agg(customer_id), 10)).*, (topn(topn_add_agg(product_id), 10)).*
-	FROM
-		customer_reviews
-) SELECT customer_item, product_item FROM cte ORDER BY floor(customer_freq/10) desc, floor(product_freq/10) desc, customer_item, product_item;
-
 SELECT
     customers.product_category, customers.item, products.item
 FROM

--- a/topn.control
+++ b/topn.control
@@ -1,4 +1,4 @@
 # topn extension
 comment = 'type for top-n JSONB'
-default_version = '2.3.0'
+default_version = '2.3.1'
 module_pathname = '$libdir/topn'


### PR DESCRIPTION
#31 wanted to bump the TopN version to 2.3.1, but there were some missing pieces:

- 2.3.1 migration file did not have a make target
- Default version in control file was not bumped

These two issues meant that the CI were still running on 2.3.0.
When I bumped the version to 2.3.1 in necessary places, one test started to fail due to parallelization.

