### PR TITLE
Stop generating migration files for each version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 MODULES = topn
 EXTENSION = topn
-EXTVERSIONS = 2.0.0 2.1.0 2.2.0 2.2.1 2.2.2 2.3.0 2.3.1 2.4.0
-DATA =	$(wildcard $(EXTENSION)--*--*.sql)
-DATA_built = $(foreach v,$(EXTVERSIONS),$(EXTENSION)--$(v).sql)
+sql_files = $(wildcard update/$(EXTENSION)--*.sql)
+generated_sql_files = $(patsubst update/%,%,$(sql_files))
+DATA_built = $(generated_sql_files)
 PG_CONFIG ?= pg_config
 
 REGRESS = add_agg union_agg char_tests null_tests add_union_tests copy_data customer_reviews_query join_tests
@@ -15,25 +15,9 @@ all:
 
 SQLPP ?= cpp -undef -w -P -imacros $(shell $(PG_CONFIG) --includedir-server)/pg_config.h
 
+# generate the sql files
 %.sql: update/%.sql
 	$(SQLPP) $^ > $@
-
-# generate each version's file installation file by concatenating
-# previous upgrade scripts
-$(EXTENSION)--2.1.0.sql: $(EXTENSION)--2.0.0.sql $(EXTENSION)--2.0.0--2.1.0.sql
-	cat $^ > $@
-$(EXTENSION)--2.2.0.sql: $(EXTENSION)--2.1.0.sql $(EXTENSION)--2.1.0--2.2.0.sql
-	cat $^ > $@
-$(EXTENSION)--2.2.1.sql: $(EXTENSION)--2.2.0.sql $(EXTENSION)--2.2.0--2.2.1.sql
-	cat $^ > $@
-$(EXTENSION)--2.2.2.sql: $(EXTENSION)--2.2.1.sql $(EXTENSION)--2.2.1--2.2.2.sql
-	cat $^ > $@
-$(EXTENSION)--2.3.0.sql: $(EXTENSION)--2.2.2.sql $(EXTENSION)--2.2.2--2.3.0.sql
-	cat $^ > $@
-$(EXTENSION)--2.3.1.sql: $(EXTENSION)--2.3.0.sql $(EXTENSION)--2.3.0--2.3.1.sql
-	cat $^ > $@
-$(EXTENSION)--2.4.0.sql: $(EXTENSION)--2.3.1.sql $(EXTENSION)--2.3.1--2.4.0.sql
-	cat $^ > $@
 
 EXTRA_CLEAN += topn--*.sql -r $(RPM_BUILD_ROOT)
 


### PR DESCRIPTION
PostgreSQL 10 introduced an improvement on extension migration paths. We
no longer need to generate a migration file for each version. It is
sufficient to have an initial script and the migration scripts that are
used to upgrade to the next version.

This commit also fixes an issue where we did not install necessary
migration files on a clean build.

Fixes: #58